### PR TITLE
fix: install bioconductor packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
+biocViews:
 Suggests: 
     testthat (== 3.1.4)
 Depends:


### PR DESCRIPTION
Solution from: https://bioinformatics.stackexchange.com/a/3375

With this addition to the description file, `devtools::install()` now installs dependencies from bioconductor too. 